### PR TITLE
liberalize xbps-usage (no use of --force)

### DIFF
--- a/src/xbpsexec.cpp
+++ b/src/xbpsexec.cpp
@@ -594,10 +594,10 @@ void XBPSExec::doCleanCache()
  */
 void XBPSExec::doInstall(const QString &listOfPackages)
 {
-  QString command = "xbps-install -f -y " + listOfPackages;
+  QString command = "xbps-install -y " + listOfPackages;
 
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-install -f " + listOfPackages + ";");
+  m_lastCommandList.append("xbps-install " + listOfPackages + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
@@ -611,7 +611,7 @@ void XBPSExec::doInstall(const QString &listOfPackages)
 void XBPSExec::doInstallInTerminal(const QString &listOfPackages)
 {
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-install -f " + listOfPackages + ";");
+  m_lastCommandList.append("xbps-install " + listOfPackages + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
@@ -654,10 +654,10 @@ void XBPSExec::doInstallLocalInTerminal(const QString &listOfPackages)
  */
 void XBPSExec::doRemove(const QString &listOfPackages)
 {
-  QString command = "xbps-remove -R -f -y " + listOfPackages;
+  QString command = "xbps-remove -R -y " + listOfPackages;
 
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackages + ";");
+  m_lastCommandList.append("xbps-remove -R " + listOfPackages + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
@@ -671,7 +671,7 @@ void XBPSExec::doRemove(const QString &listOfPackages)
 void XBPSExec::doRemoveInTerminal(const QString &listOfPackages)
 {
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackages + ";");
+  m_lastCommandList.append("xbps-remove -R  " + listOfPackages + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
@@ -684,12 +684,12 @@ void XBPSExec::doRemoveInTerminal(const QString &listOfPackages)
  */
 void XBPSExec::doRemoveAndInstall(const QString &listOfPackagestoRemove, const QString &listOfPackagestoInstall)
 {
-  QString command = "xbps-remove -R -f -y " + listOfPackagestoRemove +
-      "; xbps-install -f " + listOfPackagestoInstall;
+  QString command = "xbps-remove -R -y " + listOfPackagestoRemove +
+      "; xbps-install " + listOfPackagestoInstall;
 
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackagestoRemove + ";");
-  m_lastCommandList.append("xbps-install -f " + listOfPackagestoInstall + ";");
+  m_lastCommandList.append("xbps-remove -R " + listOfPackagestoRemove + ";");
+  m_lastCommandList.append("xbps-install  " + listOfPackagestoInstall + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 
@@ -703,8 +703,8 @@ void XBPSExec::doRemoveAndInstall(const QString &listOfPackagestoRemove, const Q
 void XBPSExec::doRemoveAndInstallInTerminal(const QString &listOfPackagestoRemove, const QString &listOfPackagestoInstall)
 {
   m_lastCommandList.clear();
-  m_lastCommandList.append("xbps-remove -R -f " + listOfPackagestoRemove + ";");
-  m_lastCommandList.append("xbps-install -f " + listOfPackagestoInstall + ";");
+  m_lastCommandList.append("xbps-remove -R  " + listOfPackagestoRemove + ";");
+  m_lastCommandList.append("xbps-install  " + listOfPackagestoInstall + ";");
   m_lastCommandList.append("echo -e;");
   m_lastCommandList.append("read -n 1 -p \"" + StrConstants::getPressAnyKey() + "\"");
 


### PR DESCRIPTION
I don't see why it is neccesary to use `-f` by default, and it indeed can create quite a mess if one is not asked before breaking software.