### PR TITLE
Fix detection of Void Linux in getLinuxDistro

### DIFF
--- a/src/unixcommand.cpp
+++ b/src/unixcommand.cpp
@@ -709,7 +709,7 @@ LinuxDistro UnixCommand::getLinuxDistro()
 
       QString contents = file.readAll();
 
-      if (contents.contains("PRETTY_NAME=\"void\""))
+      if (contents.contains("ID=\"void\""))
       {
         ret = ectn_VOID;
       }


### PR DESCRIPTION
Before this change, OctoXBPS detects Void Linux based on whether or not
the string, `PRETTY_NAME="void"`, occurs in the file, `/etc/os-release`.
As of March 15 2022, the contents of `/etc/os-release` have been changed
and `PRETTY_NAME="Void Linux"` replaces the previous value.
(see https://github.com/void-linux/void-packages/commit/1dfc401d1237120e8e936627e7e28d2441916e80)

With this change, Void Linux is detected based on the value of `ID` in
`/etc/os-release` which is less subject to change.

This change is important because OctoXBPS only checks for the existence
of the local package db if it detects that it is running on either Void
Linux or Trident Linux. If OctoXBPS does not detect that it is running
on either distribution (which it doesn't without this change), it will
prompt for elevated privileges in order to synchronize the local package
database with the remote database using `xbps-install -Syy` every time
it is started, regardless of whether or not there are remote changes
that need to be synced.

Personally, I believe that it would be better to remove the distribution
check from Package::hasXBPSDatabase as it eliminates this sort of error
happening in the future and I don't understand what is gained from
having it in the first place. However, that sort of thing is ultimately
up to you as the maintainer of this project, so I have only included a
fix for the current approach in this commit.