### PR TITLE
Standard icon path for linux

### DIFF
--- a/octoxbps.pro
+++ b/octoxbps.pro
@@ -98,7 +98,7 @@ target.path = $$BINDIR
 desktop.path = $$DATADIR/applications
 desktop.files += octoxbps.desktop
 
-icon.path = $$DATADIR/icons
+icon.path = $$DATADIR/icons/hicolor/48x48/apps
 icon.files += resources/images/octopi.png
 
 INSTALLS += target desktop icon


### PR DESCRIPTION
I think it would be better, the main icon is placed in the hicolor icon which is the standard icon for linux.

`icons/hicolor/48x48/apps`

But it would be even better if a scalable icon was provided, then placed in `icons/hicolor/scalable/apps`. Unfortunately, I didn't find the svg icon.

![Screenshot_20220505_094738](https://user-images.githubusercontent.com/45872139/166857540-22a44dc0-3f78-4d77-b465-10fe0f15bfdb.png)

