### PR TITLE
Fix notifier not showing updates

### DIFF
--- a/notifier/mainwindow.cpp
+++ b/notifier/mainwindow.cpp
@@ -571,7 +571,6 @@ void MainWindow::startPkexec()
   QProcess *xbps = new QProcess();
   connect(xbps, SIGNAL(finished(int)), this, SLOT(finishedPkexec(int)));
   QStringList sl;
-  sl << ctn_OCTOXBPS_SUDO_PARAMS;
   sl << QStringLiteral("/usr/bin/xbps-install");
   sl << QStringLiteral("-Sy");
   xbps->start("pkexec", sl);

--- a/notifier/polkit/49-nopasswd_limited_xbps_install_sync.rules
+++ b/notifier/polkit/49-nopasswd_limited_xbps_install_sync.rules
@@ -2,7 +2,7 @@
  * without password authentication, similar to "sudo NOPASSWD:"
  */
 polkit.addRule(function(action, subject) {
-    if ((action.id == "org.freedesktop.policykit.pkexec.run-xbpsinstall" &&
+    if (action.id == "org.freedesktop.policykit.pkexec.run-xbpsinstall" &&
         subject.isInGroup("wheel"))
     {
         return polkit.Result.YES;


### PR DESCRIPTION
The problem was that when `startPkexec` was changed back to using `pkexec` instead of `sudo` (794551660fb51fb5b9d449a5dcd0d1c27e31d059), the line that added `ctn_OCTOXBPS_SUDO_PARAMS` to `sl` was left in.

I've been using these changes for a day and they seem to fix #37 